### PR TITLE
サイドバーの修正、個数選択エラー表示機能を追加

### DIFF
--- a/src/main/java/com/example/Adventure/controller/OrderChangeController.java
+++ b/src/main/java/com/example/Adventure/controller/OrderChangeController.java
@@ -51,7 +51,4 @@ public class OrderChangeController {
         responseMap.put("newTotalPrice", newTotalPrice);
         return ResponseEntity.ok(responseMap);
     }
-
-
 }
-

--- a/src/main/java/com/example/Adventure/controller/ProductsController.java
+++ b/src/main/java/com/example/Adventure/controller/ProductsController.java
@@ -11,6 +11,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -36,6 +37,14 @@ public class ProductsController {
         List<Events> eventsList = eventService.findAll();
 
         Map<String, List<Products>> productsGroupedByRegion = productsList.stream()
+                .sorted(Comparator.comparingInt(product -> {
+                    String regionName = product.getRegionName();
+                    if ("Unknown".equals(regionName)) {
+                        return Integer.MAX_VALUE;
+                    } else {
+                        return product.getRegionId();
+                    }
+                }))
                 .collect(Collectors.groupingBy(product -> product.getRegionName() != null ? product.getRegionName() : "Unknown"));
 
         model.addAttribute("productsByRegion", productsGroupedByRegion);

--- a/src/main/java/com/example/Adventure/form/ShoppingCartsForm.java
+++ b/src/main/java/com/example/Adventure/form/ShoppingCartsForm.java
@@ -1,0 +1,43 @@
+package com.example.Adventure.form;
+
+import jakarta.validation.constraints.Size;
+
+public class ShoppingCartsForm {
+    private Integer cartId;
+    private Integer userId;
+    private Integer productId;
+    @Size(min=1, message = "数量は1以上を選択してください。")
+    private Integer quantity;
+
+    public Integer getCartId() {
+        return cartId;
+    }
+
+    public void setCartId(Integer cartId) {
+        this.cartId = cartId;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+
+    public Integer getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Integer productId) {
+        this.productId = productId;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/com/example/Adventure/repository/ProductsRepository.java
+++ b/src/main/java/com/example/Adventure/repository/ProductsRepository.java
@@ -38,7 +38,7 @@ public class ProductsRepository {
     public List<Products> findAll() {
         String sql = "SELECT p.product_id, p.region_id, p.producer_id, p.product_name, p.description, p.price, p.image_url, r.region_name " +
                 "FROM products p JOIN regions r ON p.region_id = r.region_id " +
-                "ORDER BY p.region_id";
+                "ORDER BY r.region_id";
         List<Products> productsList = template.query(sql, PRODUCTS_ROW_MAPPER);
         return productsList;
     }

--- a/src/main/resources/sql/adventure.sql
+++ b/src/main/resources/sql/adventure.sql
@@ -186,24 +186,11 @@ VALUES
     (8, 1, '宮崎産マンゴー', '夏の期間限定で出回る高級フルーツです。', 3000, 'miyazaki_mango.png'),
     (8, 2, '佐賀産いちご', '甘さと酸味のバランスが絶妙です。', 600, 'saga_strawberry.png');
 
-
  -- 沖縄県の商品
  INSERT INTO products (region_id, producer_id, product_name, description, price, image_url)
  VALUES
      (9, 1, '沖縄そば', '沖縄独特のソウルフードで、麺が太くて美味しいです。', 700, 'okinawa_soba.png'),
      (9, 2, 'ゴーヤチャンプルー', 'ゴーヤの苦味が特徴的な沖縄料理です。', 650, 'goya.png');
-
----- Order Details Table
---INSERT INTO order_details (order_id, product_id, quantity, subtotal_price)
---VALUES
---    (1, 1, 2, 600),
---    (2, 2, 3, 1500);
---
----- Stamps Table
---INSERT INTO stamps (user_id, region_id, stamp_date)
---VALUES
---    (1, 1, now()),
---    (2, 2, now());
 
 -- Events Table
 INSERT INTO events (region_id, event_name, description, event_location)

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -241,12 +241,16 @@ footer a, footer .nav-link, footer p {
 /* サイドバー */
 .aside-right {
     position: fixed;
+    top: 90px; /* 修正: 画面上部からの位置を調整 */
+    bottom: 0;
+    overflow-y: auto; /* スクロールバーを追加 */
+    max-height: calc(100vh - 40px); /* ビューポートの高さから上部のナビゲーションバーの高さを差し引く */
     flex: 1;
     padding: 20px;
-    /*background-color: rgba(255, 255, 255, 0.7);*/
+    overflow-y: auto; /* スクロールバーを追加 */
     border-radius: 15px;
-    margin-top: 70px; /* 修正: 上からの位置を指定 */
-    right: 20px; /* 修正: 右からの位置を指定 */
+    margin-top: 40px;
+    right: 20px;
 }
 
 .login-form {
@@ -467,7 +471,7 @@ font-size:20px;
 
 }
 
-     .order-completed {
+.order-completed {
             text-align: center;
             background: linear-gradient(to bottom right, #FFB6C1, #FF69B4);
             border-radius: 15px;
@@ -555,6 +559,27 @@ font-size:20px;
     color: #696969;
 }
 
+@media (min-width: 768px) {
+    .aside-right {
+        font-size: 18px;
+    }
+}
 
+@media (max-width: 767px) {
+    .aside-right {
+        font-size: 12px;
+    }
+}
 
+@media (max-width: 576px) {
+    .aside-right {
+        font-size: 10px;
+    }
+}
+
+@media (max-width: 480px) {
+    .aside-right {
+        font-size: 8px;
+    }
+}
 

--- a/src/main/resources/static/js/aside-right.js
+++ b/src/main/resources/static/js/aside-right.js
@@ -1,11 +1,13 @@
 "use strict"
 
-function countryClicked(id){
-	if(document.getElementById("list"+id).style.display==="none"){
-		document.getElementById("list"+id).style.display="block";
-		document.getElementById(id).innerText="" + id + "▽";
-	}else{
-		document.getElementById("list"+id).style.display="none";
-		document.getElementById(id).innerText="" + id + "▷";
-	}
+function countryClicked(id) {
+    var listElement = document.getElementById("list" + id);
+
+    if (listElement.style.display === "none") {
+        listElement.style.display = "block";
+        document.getElementById(id).innerText = "" + id + "▽";
+    } else {
+        listElement.style.display = "none";
+        document.getElementById(id).innerText = "" + id + "▷";
+    }
 }

--- a/src/main/resources/static/js/header.js
+++ b/src/main/resources/static/js/header.js
@@ -1,0 +1,18 @@
+    $(document).ready(function () {
+        // 画面内遷移用のリンクがクリックされた時の処理
+        $(".scroll-link").on("click", function (event) {
+            event.preventDefault();
+
+            // 対象のセクションの位置を取得
+            var target = $(this.hash);
+            var targetOffset = target.offset().top;
+
+            // ヘッダーの高さを取得
+            var headerHeight = $("header").outerHeight();
+
+            // スクロール位置を設定（ヘッダーの高さを考慮）
+            $("html, body").animate({
+                scrollTop: targetOffset - headerHeight
+            }, 600);
+        });
+    });

--- a/src/main/resources/static/js/popular.js
+++ b/src/main/resources/static/js/popular.js
@@ -1,0 +1,26 @@
+"use strict"
+
+    document.addEventListener("DOMContentLoaded", function () {
+        // スライドのインターバル（ミリ秒）
+        var interval = 5000; // 5秒ごとにスライド
+
+        // スライダー要素の取得
+        var slider = document.querySelector('.top-product-slider');
+
+        // 一つの商品コンテナの幅を取得
+        var productWidth = document.querySelector('.product-container').offsetWidth;
+
+        // スライドの実行
+        function slide() {
+            // スライダーを左に1つ分の商品コンテナ幅だけ移動
+            slider.style.transform = 'translateX(-' + productWidth + 'px)';
+
+            // 一定時間経過後に元の位置に戻す
+            setTimeout(function () {
+                slider.style.transform = 'translateX(0)';
+            }, 1000); // 1秒後に元に戻す（この時間はスライド時間より大きくする）
+        }
+
+        // インターバルごとにスライドを実行
+        setInterval(slide, interval);
+    });

--- a/src/main/resources/static/js/script.js
+++ b/src/main/resources/static/js/script.js
@@ -1,5 +1,11 @@
 function amountChange(id, value, productId) {
     console.log(`Changing amount for productId: ${productId}, value: ${value}`);
+
+    if (value <= 0) {
+        alert("数量は1以上を選択してください。");
+        return;
+    }
+
     fetch(`/change-order/amount?productId=${productId}&value=${value}`, {
         method: 'GET'
     }).then(response => {

--- a/src/main/resources/templates/order-completed.html
+++ b/src/main/resources/templates/order-completed.html
@@ -24,6 +24,5 @@
     <a th:href="@{/top/back}">戻る</a>
 </div>
 </div>
-    
 </body>
 </html>

--- a/src/main/resources/templates/shopping-cart.html
+++ b/src/main/resources/templates/shopping-cart.html
@@ -46,7 +46,6 @@
                         <input type="hidden" name="description" th:value="${cartDetail.description}">
                         <button class="shopping-cart-btn" type="submit">削除</button>
                     </form>
-
                     <label for="confirm-quantity-input${status.index}">
                         <div class="shopping-cart-quantity">
                             <div class="confirm-quantity-label">
@@ -61,7 +60,6 @@
                                    min="1">個
                         </div>
                     </label>
-
                     <div class="shopping-cart-content-right">
                         <div class="shopping-cart-image-url">
                             <img th:src="@{/img/{imageName}(imageName=${cartDetail.imageUrl})}" alt="Product Image"/>
@@ -74,18 +72,15 @@
             <p th:text="'合計: ' + ${totalPrice} + '円'"></p>
         </div>
         <a th:href="@{/top/back}">戻る</a>
-        <form th:action="@{/order/order-confirmation}" method="get">
-            <button>注文確認へ</button>
+        <form th:action="@{/order/order-confirmation}" method="get" id="orderConfirmationForm">
+            <button onclick="validateQuantity()">注文確認へ</button>
         </form>
     </div>
 </div>
 </div>
-
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-
 <script src="/js/script.js" th:src="@{/js/script.js}"></script>
-
 </body>
 </html>

--- a/src/main/resources/templates/top.html
+++ b/src/main/resources/templates/top.html
@@ -7,7 +7,6 @@
     <link rel="icon" th:href="@{/img/favicon.ico}">
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
-    　　
     <link rel="stylesheet" th:href="@{/css/style.css}">
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Rounded+Mplus+1c:wght@300;400;500&display=swap"
@@ -16,9 +15,7 @@
 
 </head>
 <body class="bg-light" style="display: flex;">
-
 <div class="main-content" style="flex: 4; padding: 20px;">
-
     <header class="text-brack py-3">
         <div class="container">
             <h1 class="text-center">食の冒険</h1>
@@ -26,10 +23,10 @@
         <nav class="navbar navbar-expand-lg">
             <div class="container">
                 <ul class="navbar-nav mr-auto">
-                    <li class="nav-item"><a class="nav-link" href="#regions">地域を探す</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#popular">人気商品</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#events">イベント情報</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#stamp">スタンプカード</a></li>
+                    <li class="nav-item"><a class="nav-link scroll-link" href="#regions">地域を探す</a></li>
+                    <li class="nav-item"><a class="nav-link scroll-link" href="#popular">人気商品</a></li>
+                    <li class="nav-item"><a class="nav-link scroll-link" href="#events">イベント情報</a></li>
+                    <li class="nav-item"><a class="nav-link scroll-link" href="#stamp">スタンプカード</a></li>
                 </ul>
                 <div class="ml-auto">
                     <ul class="navbar-nav">
@@ -60,7 +57,6 @@
                 </div>
             </div>
         </nav>
-
     </header>
 
     <div class="container-fluid my-5">
@@ -113,7 +109,6 @@
                     </div>
                 </div>
             </section>
-
             <section id="product-list" class="my-box my-5">
                 <h2 class="mb-3">商品一覧</h2>
                 <div class="productsList">
@@ -142,27 +137,28 @@
                     </div>
                 </div>
             </section>
-            <section id="top" class="my-box my-5">
+            <section id="popular" class="my-box my-5">
                 <h2 class="mb-3">人気商品</h2>
                 <div class="row">
-                    <div th:each="product: ${topProducts}" class="col-sm-4">
-                        <div class="product-list-image">
-                            <a href="product-detail.html" th:href="@{/top/showDetail/}+${product.productId}">
-                                <img th:src="@{/img/{imageName}(imageName=${product.imageUrl})}" alt="Product Image" class="img-fluid"/>
-                            </a>
-                        </div>
-                        <div class="product-image-spacer"></div>
-                        <div class="col-sm-6">
-                            <a href="product-detail.html" th:href="@{/top/showDetail/}+${product.productId}">
-                                <p class="product-name font-weight-bold"><span th:text="${product.productName}"></span></p>
-                            </a>
-                            <p class="product-price"><span th:text="${product.price}"></span>円</p>
-                            <p class="product-description"><span th:text="${product.description}"></span></p>
+                        <div th:each="product: ${topProducts}" class="col-sm-4">
+                            <div class="product-list-image">
+                                <a href="product-detail.html" th:href="@{/top/showDetail/}+${product.productId}">
+                                    <img th:src="@{/img/{imageName}(imageName=${product.imageUrl})}" alt="Product Image"
+                                         class="img-fluid"/>
+                                </a>
+                            </div>
+                            <div class="product-image-spacer"></div>
+                            <div class="col-sm-6">
+                                <a href="product-detail.html" th:href="@{/top/showDetail/}+${product.productId}">
+                                    <p class="product-name font-weight-bold"><span
+                                            th:text="${product.productName}"></span></p>
+                                </a>
+                                <p class="product-price"><span th:text="${product.price}"></span>円</p>
+                                <p class="product-description"><span th:text="${product.description}"></span></p>
+                            </div>
                         </div>
                     </div>
-                </div>
             </section>
-
             <section id="events" class="my-box my-5">
                 <h2 class="mb-3">イベント情報</h2>
                 <div th:each="event:${eventsList}" class="event-list">
@@ -177,24 +173,21 @@
                 <h2 class="mb-3">スタンプカード</h2>
                 <a th:href="@{/to-stamp-card}" method="get">スタンプカードへ</a>
             </section>
-
         </div>
         <div class="aside-right col-2">
             <div th:include="./html_mock/aside-right :: frag_aside-right"></div>
         </div>
-
     </div>
-
 
     <footer class="text-brack text-center py-3">
         <div class="container-fluid my-box">
             <nav class="navbar navbar-expand-lg navbar-dark">
                 <div class="container">
                     <ul class="navbar-nav mr-auto">
-                        <li class="nav-item"><a class="nav-link" href="#regions">地域を探す</a></li>
-                        <li class="nav-item"><a class="nav-link" href="#popular">人気商品</a></li>
-                        <li class="nav-item"><a class="nav-link" href="#events">イベント情報</a></li>
-                        <li class="nav-item"><a class="nav-link" href="#stamp">スタンプカード</a></li>
+                        <li class="nav-item"><a class="nav-link scroll-link" href="#regions">地域を探す</a></li>
+                        <li class="nav-item"><a class="nav-link scroll-link" href="#popular">人気商品</a></li>
+                        <li class="nav-item"><a class="nav-link scroll-link" href="#events">イベント情報</a></li>
+                        <li class="nav-item"><a class="nav-link scroll-link" href="#stamp">スタンプカード</a></li>
                     </ul>
                     <div class="ml-auto">
                         <ul class="navbar-nav">
@@ -228,11 +221,10 @@
             <p>&copy; 2023 食の冒険. All rights reserved.</p>
         </div>
     </footer>
-
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-
     <!--<script src="scripts.js"></script>-->
+        <script src="/js/header.js" th:src="@{/js/header.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
サイドバーの地域を展開して画面いっぱいになったらサイドバーのスクロールバーが表示され、サイドバーを固定しつつ、スクロールバーで下まで見れるように修正しました。

ショッピングカート画面でマイナスや0個で購入できてしまっていたエラーは1未満の数が入力された状態で注文確認ボタンを押すとalert機能で警告が出て先に進めないようにしました。